### PR TITLE
fix(worker,db): 予約投稿の時刻フォーマットJST統一と設定初期値の是正（イシュー#1）

### DIFF
--- a/apps/worker/src/services/week-schedule-time.ts
+++ b/apps/worker/src/services/week-schedule-time.ts
@@ -1,4 +1,7 @@
 //20260614新規追加開始
+// next_run_at も他の時刻カラムと同じ JST(+09:00) 形式で揃える。
+import { toJstString } from '@x-harness/db';
+
 export type WeeklyScheduleTime = {
   weekday: number | string;
   time: string;
@@ -169,6 +172,6 @@ export function calculateNextWeeklyRunAt(
     targetUtc = buildTarget(daysUntil + 7);
   }
 
-  return targetUtc.toISOString();
+  return toJstString(targetUtc);
 }
 //20260614新規追加終了

--- a/apps/worker/src/services/week-scheduler.ts
+++ b/apps/worker/src/services/week-scheduler.ts
@@ -2,6 +2,9 @@
 //20260614修正開始
 import { calculateNextWeeklyRunAt } from './week-schedule-time.js';
 //20260614修正終了
+// scheduled_at の比較(getDueScheduledPosts)は JST(+09:00) 文字列前提のため、
+// ここで保存する時刻も jstNow() に統一する。
+import { jstNow } from '@x-harness/db';
 
 export async function processWeeklySchedules(
   db: D1Database
@@ -30,7 +33,8 @@ export async function processWeeklySchedules(
 
   for (const week of weeks.results) {
     const nowUTC = new Date();
-    const now = nowUTC.toISOString();
+    // DB 保存・文字列比較用は JST(+09:00) 形式に統一。時刻計算(getTime比較)には nowUTC を使う。
+    const now = jstNow();
 
     console.log('[week-scheduler:start]', {
       id: week.id,
@@ -40,7 +44,7 @@ export async function processWeeklySchedules(
       timezone: week.timezone,
       next_run_at: week.next_run_at,
       last_posted_at: week.last_posted_at,
-      now_utc: now,
+      now_jst: now,
     });
 
     // ===============================
@@ -79,7 +83,7 @@ export async function processWeeklySchedules(
     console.log('[week-scheduler:check next_run_at]', {
       id: week.id,
       next_run_at: week.next_run_at,
-      now_utc: now,
+      now_jst: now,
     });
 
     if (nextRunAtDate.getTime() > nowUTC.getTime()) {

--- a/packages/db/migrations/011-settings-and-line-connections.sql
+++ b/packages/db/migrations/011-settings-and-line-connections.sql
@@ -7,13 +7,6 @@ CREATE TABLE IF NOT EXISTS settings (
   updated_at TEXT NOT NULL
 );
 
---202606追加開始
-INSERT OR IGNORE INTO settings (key, value, updated_at)
-VALUES
-  ('posting_enabled', 'true', datetime('now')),
-  ('auto_features_enabled', 'true', datetime('now'));
---202606追加終了
-
 CREATE TABLE IF NOT EXISTS line_connections (
   id TEXT PRIMARY KEY,
   name TEXT NOT NULL,

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -243,12 +243,6 @@ CREATE TABLE IF NOT EXISTS settings (
   value TEXT NOT NULL,
   updated_at TEXT NOT NULL
 );
--- 202606新規追加開始
-INSERT OR IGNORE INTO settings (key, value, updated_at)
-VALUES
-  ('posting_enabled', 'true', datetime('now')),
-  ('auto_features_enabled', 'true', datetime('now'));
--- 202606新規追加終了
 
 -- LINE Connections (L Harness 連携先)
 CREATE TABLE IF NOT EXISTS line_connections (


### PR DESCRIPTION
イシュー#1（Typefully風の予約投稿スケジューラ）の main 実装に対する是正。

## 変更点

### 1. 予約投稿の時刻フォーマットを JST(+09:00) に統一 🔴
`week-scheduler` だけが UTC(`...Z`) 形式で時刻を保存しており、due 判定
(`getDueScheduledPosts` の `scheduled_at <= jstNow()` 文字列比較）や
`createScheduledPost` が前提とする JST(`+09:00`) 形式と混在していた。
形式不一致により **due 比較・並び順が壊れ、jitter も意図どおり機能しない**。

- `week-scheduler.ts`: `now` を `nowUTC.toISOString()` → `jstNow()` に変更
  （`scheduled_at`/`created_at`/`updated_at`/`last_posted_at` を JST に統一）。
  時刻計算（`getTime()` 比較）用に `nowUTC`(Date) はそのまま保持。
- `week-schedule-time.ts`: `calculateNextWeeklyRunAt` の戻り値を
  `toISOString()` → `toJstString()` に変更（`next_run_at` も JST に統一）。
- 旧 UTC 値が DB に残っていても `new Date()` でパース可能なため自己修復し、
  楽観ロック（`WHERE next_run_at = ?`）も一貫した形式で二重投稿を防ぐ。

### 2. settings 初期値 INSERT の削除 / 011 マイグレーションの不変性復元 🟠
- `schema.sql`: `auto_features_enabled='true'` 等の初期値 INSERT を削除。
  自動機能はコストガードのため **デフォルト OFF** が方針
  （`index.ts` の `getSettingBool` が未登録を `false` 扱い）。
- `011` migration: 適用済みファイルへの事後改変を元に戻す（不変性の遵守）。
- 未参照の `posting_enabled` 設定も除去。

## 補足
- `database_id` は方針変更により **現行の開発用値(1480fd89) を維持**するため本PRでは変更しない。
- `scheduled_weeks` テーブル等、イシュー#1本体の実装はそのまま維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)